### PR TITLE
Remove invalid command from commands enum #57

### DIFF
--- a/src/main/java/seedu/duke/common/DashboardCommands.java
+++ b/src/main/java/seedu/duke/common/DashboardCommands.java
@@ -1,5 +1,8 @@
 package seedu.duke.common;
 
+/**
+ * Enum class for all commands available at the dashboard.
+ */
 public enum DashboardCommands {
 
     HELP("help", "Lists out all commands available when a module isn't selected."),
@@ -7,8 +10,7 @@ public enum DashboardCommands {
     OPEN("open", "Opens the specified module."),
     ADD("add", "Adds a new module with specified name."),
     DELETE("delete", "Deletes the specified module."),
-    MODULES("modules", "Lists all modules."),
-    INVALID("unknown", "Unrecognized command.");
+    MODULES("modules", "Lists all modules.");
 
     private final String word;
     private final String description;
@@ -24,5 +26,19 @@ public enum DashboardCommands {
 
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * Takes in user input and returns appropriate DashboardCommands object.
+     * @param input user input string
+     * @return DashboardCommands object based on user input, null if there is no match
+     */
+    public static DashboardCommands fromInput(String input) {
+        for (DashboardCommands command : DashboardCommands.values()) {
+            if (input.equalsIgnoreCase(command.getWord())) {
+                return command;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/seedu/duke/common/ModuleCommands.java
+++ b/src/main/java/seedu/duke/common/ModuleCommands.java
@@ -1,5 +1,8 @@
 package seedu.duke.common;
 
+/**
+ * Enum class for all commands available inside a module.
+ */
 public enum ModuleCommands {
 
     HELP("help", "List out commands available for the selected module."),
@@ -14,8 +17,7 @@ public enum ModuleCommands {
     DELETE_TASK("delete task", "Deletes specified tasks."),
     MARK("mark", "Marks specified tasks as done."),
     UNMARK("unmark", "Marks specified tasks as undone."),
-    TASKS("tasks", "Lists all tasks."),
-    INVALID("unknown", "Unrecognized command.");
+    TASKS("tasks", "Lists all tasks.");
 
     private final String word;
     private final String description;
@@ -31,5 +33,19 @@ public enum ModuleCommands {
 
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * Takes in user input and returns appropriate ModuleCommands object.
+     * @param input user input string
+     * @return ModuleCommands object based on user input, null if there is no match
+     */
+    public static ModuleCommands fromInput(String input) {
+        for (ModuleCommands command : ModuleCommands.values()) {
+            if (input.equalsIgnoreCase(command.getWord())) {
+                return command;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -97,7 +97,7 @@ public class Parser {
      * @throws UnknownCommandException if valid command cannot be parsed from user input
      */
     private Command parseAtDashboard(String input) throws UnknownCommandException {
-        DashboardCommands command = parseDashboardCommandFromInput(input);
+        DashboardCommands command = DashboardCommands.fromInput(input);
         switch (command) {
         case ADD:
             String moduleCode = getModuleCode(input);
@@ -114,30 +114,6 @@ public class Parser {
             return new ExitProgramCommand();
         default:
             throw new UnknownCommandException();
-        }
-    }
-
-    /**
-     * Parses user input to determine the dashboard command specified.
-     *
-     * @param input full user input string
-     * @return an integer representing the command specified
-     */
-    private DashboardCommands parseDashboardCommandFromInput(String input) {
-        if (input.equalsIgnoreCase(DashboardCommands.HELP.getWord())) {
-            return DashboardCommands.HELP;
-        } else if (input.equalsIgnoreCase(EXIT.getWord())) {
-            return EXIT;
-        } else if (input.equalsIgnoreCase(MODULES.getWord())) {
-            return MODULES;
-        } else if (startsWith(input, ADD.getWord())) {
-            return ADD;
-        } else if (startsWith(input, DELETE.getWord())) {
-            return DELETE;
-        } else if (isValidModuleCode(input)) {
-            return OPEN;
-        } else {
-            return DashboardCommands.INVALID;
         }
     }
 
@@ -196,7 +172,7 @@ public class Parser {
      * @throws UnknownCommandException if valid command cannot be parsed from user input
      */
     private Command parseInModule(String input) throws UnknownCommandException {
-        ModuleCommands command = parseInModuleCommandsFromInput(input);
+        ModuleCommands command = ModuleCommands.fromInput(input);
 
         switch (command) {
         case HELP:
@@ -229,44 +205,6 @@ public class Parser {
             return new DeleteTaskCommand();
         default:
             throw new UnknownCommandException();
-        }
-    }
-
-    /**
-     * Parses user input to determine in-module command specified.
-     *
-     * @param input full user input string
-     * @return an integer representing the command specified
-     */
-    private ModuleCommands parseInModuleCommandsFromInput(String input) {
-        if (input.equalsIgnoreCase(ModuleCommands.HELP.getWord())) {
-            return ModuleCommands.HELP;
-        } else if (input.equalsIgnoreCase(CLOSE.getWord())) {
-            return CLOSE;
-        } else if (input.equalsIgnoreCase(INFO.getWord())) {
-            return INFO;
-        } else if (input.equalsIgnoreCase(LESSONS.getWord())) {
-            return LESSONS;
-        } else if (input.equalsIgnoreCase(LINK.getWord())) {
-            return LINK;
-        } else if (input.equalsIgnoreCase(TASKS.getWord())) {
-            return TASKS;
-        } else if (input.equalsIgnoreCase(MARK.getWord())) {
-            return MARK;
-        } else if (input.equalsIgnoreCase(UNMARK.getWord())) {
-            return UNMARK;
-        } else if (input.equalsIgnoreCase(TEACHER.getWord())) {
-            return TEACHER;
-        } else if (startsWith(input, ADD_LESSON.getWord())) {
-            return ADD_LESSON;
-        } else if (startsWith(input, DELETE_LESSON.getWord())) {
-            return DELETE_LESSON;
-        } else if (startsWith(input, ADD_TASK.getWord())) {
-            return ADD_TASK;
-        } else if (startsWith(input, DELETE_TASK.getWord())) {
-            return DELETE_TASK;
-        } else {
-            return ModuleCommands.INVALID;
         }
     }
 


### PR DESCRIPTION
- Replace methods in parser to use class-level methods of enum
- Remove invalid command from commands instead of hiding it since does not need to be used

Resolves #57