### PR TITLE
FIx parser and editLesson UI

### DIFF
--- a/src/main/java/seedu/duke/commands/EditLessonCommand.java
+++ b/src/main/java/seedu/duke/commands/EditLessonCommand.java
@@ -178,24 +178,24 @@ public class EditLessonCommand extends Command {
         switch (fieldIndex) {
         case EDIT_INDEX_DAY_TIME:
             lesson.setTime(newFieldValue);
-            ui.printMessage(String.format(MESSAGE_LESSON_TIME_UPDATED, newFieldValue));
+            ui.printMessage(MESSAGE_LESSON_TIME_UPDATED);
             break;
         case EDIT_INDEX_LINK:
             if (Lesson.isValidLink(newFieldValue)) {
                 lesson.setOnlineLink(newFieldValue);
-                ui.printMessage(String.format(MESSAGE_LINK_UPDATED, newFieldValue));
+                ui.printMessage(MESSAGE_LINK_UPDATED);
             } else {
                 ui.printMessage(MESSAGE_INVALID_LESSON_LINK + MESSAGE_NOT_UPDATED);
             }
             break;
         case EDIT_INDEX_TEACHER_NAME:
             lesson.getTeachingStaff().setName(newFieldValue);
-            ui.printMessage(String.format(MESSAGE_TEACHER_NAME_UPDATED, newFieldValue));
+            ui.printMessage(MESSAGE_TEACHER_NAME_UPDATED);
             break;
         default:
             if (TeachingStaff.isValidEmail(newFieldValue)) {
                 lesson.getTeachingStaff().setEmail(newFieldValue);
-                ui.printMessage(String.format(MESSAGE_TEACHER_EMAIL_UPDATED, newFieldValue));
+                ui.printMessage(MESSAGE_TEACHER_EMAIL_UPDATED);
             } else {
                 ui.printMessage(MESSAGE_INVALID_LESSON_EMAIL + MESSAGE_NOT_UPDATED);
             }

--- a/src/main/java/seedu/duke/common/Messages.java
+++ b/src/main/java/seedu/duke/common/Messages.java
@@ -82,13 +82,13 @@ public class Messages {
     public static final String MESSAGE_LESSON_FIELD_TO_EDIT = "Which fields would you like to edit?";
     public static final String PROMPT_ENTER_FIELD_DETAILS = "Enter new %s:";
 
-    public static final String MESSAGE_TEACHER_NAME_UPDATED = "Teaching staff updated to: %s";
-    public static final String MESSAGE_TEACHER_EMAIL_UPDATED = "Teaching staff email updated to: %s";
-    public static final String MESSAGE_LINK_UPDATED = "Lesson link updated to: %s";
-    public static final String MESSAGE_LESSON_TIME_UPDATED = "Lesson time/day updated to: %s";
+    public static final String MESSAGE_TEACHER_NAME_UPDATED = "Updated teaching staff name.\n";
+    public static final String MESSAGE_TEACHER_EMAIL_UPDATED = "Updated teaching staff email.\n";
+    public static final String MESSAGE_LINK_UPDATED = "Updated lesson link.\n";
+    public static final String MESSAGE_LESSON_TIME_UPDATED = "Updated time and day.\n";
     
     public static final String WARNING_NO_VALID_INPUT = "No valid inputs received, lesson unchanged.";
-    public static final String  MESSAGE_NOT_UPDATED = "Field not updated.";
+    public static final String  MESSAGE_NOT_UPDATED = "Field not updated.\n";
     public static final String  MESSAGE_NO_CHANGES = "No changes to lesson list.";
 
     public static final String MESSAGE_LESSONS_LIST_EMPTY = "Your list of lessons is empty.";

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -128,20 +128,27 @@ public class Parser {
         case ADD:
             String moduleCodeToAdd = parseModuleCode(commandArgs);
             return new AddModuleCommand(moduleCodeToAdd);
-        case DELETE:
-            return new DeleteModuleCommand();
-        case MODULES:
-            return new ListModulesCommand();
         case OPEN:
             String moduleCodeToOpen = parseModuleCode(commandArgs);
             return new EnterModuleCommand(moduleCodeToOpen);
+        }
+        
+        if (!commandArgs.isEmpty()) {
+            throw new ParserException(MESSAGE_UNKNOWN_COMMAND);
+        }
+        switch (command) {
         case HELP:
             return new PrintHelpCommand();
         case EXIT:
             return new ExitProgramCommand();
+        case DELETE:
+            return new DeleteModuleCommand();
+        case MODULES:
+            return new ListModulesCommand();
         default:
             throw new ParserException(MESSAGE_UNKNOWN_COMMAND);
         }
+        
     }
 
     /**

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -140,6 +140,7 @@ public class Parser {
         if (!commandArgs.isEmpty()) {
             throw new ParserException(MESSAGE_UNKNOWN_COMMAND);
         }
+        
         switch (command) {
         case HELP:
             return new PrintHelpCommand();

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -124,6 +124,7 @@ public class Parser {
             throw new ParserException(MESSAGE_INVALID_COMMAND);
         }
 
+        // commands which require arguments
         switch (command) {
         case ADD:
             String moduleCodeToAdd = parseModuleCode(commandArgs);
@@ -131,8 +132,11 @@ public class Parser {
         case OPEN:
             String moduleCodeToOpen = parseModuleCode(commandArgs);
             return new EnterModuleCommand(moduleCodeToOpen);
+        default:
+            // Fallthrough
         }
         
+        // commands which do not require arguments
         if (!commandArgs.isEmpty()) {
             throw new ParserException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -32,14 +32,14 @@ class ParserTest {
     public static final String ADD_MODULE = "add CS2113T";
     public static final String HELP = "help";
     public static final String OPEN_MODULE = "open cs1234";
-    public static final String DELETE_MODULE = "delete cs1234";
+    public static final String DELETE_MODULE = "delete";
     public static final String ARBITRARY_STRING = "AakjhdLKLlkjlLJAAasldkj 12801 =123-=-';";
     
     
     //@@author ivanchongzhien
     @Test
     // DASHBOARD COMMANDS
-    void parse_dashboardCommandAddModule_addCommandObject() throws CommandException,
+    void parse_dashboardCommands_correctCommandObject() throws CommandException,
             ParserException {
         ModuleList.reset();
 
@@ -60,7 +60,7 @@ class ParserTest {
 
     @Test
     // IN MODULE COMMAND
-    void parse_inModuleCommandListTask_ListTaskCommandObject() throws CommandException, ParserException {
+    void parse_inModuleCommands_correctCommandObject() throws CommandException, ParserException {
         ModuleList.addModule(MODULE_CODE);
         ModuleList.setSelectedModule(MODULE_CODE);
 


### PR DESCRIPTION
- Fix dashboard command bug which ignored arguments for commands which do not need arguments. eg: "delete lesson" runs delete module command.
- Commands which do not need arguments are now recognised as unknown command if arguments are present.

- Remove parser UI which echoes user input, added new line after each updated message.